### PR TITLE
Fix Startup Issues in IWA NTLM connector

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.iwa.ntlm/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/ntlm/internal/IWAAuthenticatorServiceComponent.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.iwa.ntlm/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/ntlm/internal/IWAAuthenticatorServiceComponent.java
@@ -21,6 +21,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.eclipse.equinox.http.helper.ContextPathServletAdaptor;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Component;
 import org.osgi.service.http.HttpService;
 import org.osgi.service.http.NamespaceException;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
@@ -31,13 +32,9 @@ import org.wso2.carbon.identity.application.authenticator.iwa.ntlm.servlet.IWASe
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 
-
-/**
- * @scr.component name="identity.application.authenticator.basicauth.component" immediate="true"
- * @scr.reference name="osgi.httpservice" interface="org.osgi.service.http.HttpService"
- * cardinality="1..1" policy="dynamic" bind="setHttpService"
- * unbind="unsetHttpService"
- */
+@Component(
+        name = "identity.application.authenticator.iwa.ntlm.component",
+        immediate = true)
 public class IWAAuthenticatorServiceComponent {
 
     private static final Log log = LogFactory.getLog(IWAAuthenticatorServiceComponent.class);

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
     <properties>
         <!--Carbon Identity Framework Version-->
         <carbon.identity.framework.version>5.20.254</carbon.identity.framework.version>
-        <carbon.identity.framework.import.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.import.version.range>
+        <carbon.identity.framework.import.version.range>[5.0.0, 8.0.0)</carbon.identity.framework.import.version.range>
 
         <!-- Carbon Identity Local Authenticator IWA version -->
         <identity.local.auth.iwa.export.version>${project.version}</identity.local.auth.iwa.export.version>


### PR DESCRIPTION
## Purpose

Fix following issues Identified in the server startup when IWA NTLM connector was added.

1. Framework version range was outdated in the ocnnector and due to that following OSGI error was thrown.

    ```
    [2025-12-16 12:23:43,323] [] ERROR {Events.Framework} - FrameworkEvent ERROR org.osgi.framework.BundleException: Could not resolve module: org.wso2.carbon.identity.application.authenticator.iwa.ntlm [252]
      Unresolved requirement: Import-Package: org.wso2.carbon.identity.application.authentication.framework; version="[5.0.0,6.0.0)"
    ```

2.  The jar obtained by building the master branch of the ntlm connector is not compatible with the later IS versions. The following OSGI error is thrown since both org.wso2.carbon.identity.application.authenticator.iwa.ntlm.internal.IWAAuthenticatorServiceComponent and org.wso2.carbon.identity.application.authenticator.basicauth.internal.BasicAuthenticatorServiceComponent have same OSGI component name identity.application.authenticator.basicauth.component.

    ```
    [2025-12-16 14:00:00,186] []  WARN {org.wso2.carbon.identity.application.authenticator.iwa.ntlm} - [SCR] Found components with duplicated names! Details:
    Component1 : Component[
	    name = identity.application.authenticator.basicauth.component
	    factory = null
	    autoenable = true
	    immediate = true
	    implementation = org.wso2.carbon.identity.application.authenticator.iwa.ntlm.internal.IWAAuthenticatorServiceComponent
	    state = Unsatisfied
	    properties = {service.pid=identity.application.authenticator.basicauth.component}
	    serviceFactory = false
	    serviceInterface = null
	    references = {
		    Reference[name = osgi.httpservice, interface = org.osgi.service.http.HttpService, policy = dynamic, cardinality = 1..1, target = null, bind = setHttpService, unbind = unsetHttpService]
	    }
	    located in bundle = org.wso2.carbon.identity.application.authenticator.iwa.ntlm_5.2.8.SNAPSHOT [252]
    ]
    Component2: Component[
	    name = identity.application.authenticator.basicauth.component
	    factory = null
	    autoenable = true
	    immediate = true
	    implementation = org.wso2.carbon.identity.application.authenticator.basicauth.internal.BasicAuthenticatorServiceComponent
	    state = Unsatisfied
	    properties =
	    serviceFactory = false
	    serviceInterface = null
	    references = {
		    Reference[name = IdentityGovernanceService, interface = org.wso2.carbon.identity.governance.IdentityGovernanceService, policy = dynamic, cardinality = 1..1, target = null, bind = setIdentityGovernanceService, unbind = unsetIdentityGovernanceService]
		    Reference[name = MultiAttributeLoginService, interface = org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService, policy = dynamic, cardinality = 1..1, target = null, bind = setMultiAttributeLoginService, unbind = unsetMultiAttributeLoginService]
		    Reference[name = realm.service, interface = org.wso2.carbon.user.core.service.RealmService, policy = dynamic, cardinality = 1..1, target = null, bind = setRealmService, unbind = unsetRealmService]
		    Reference[name = resource.configuration.manager, interface = org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager, policy = dynamic, cardinality = 1..1, target = null, bind = registerConfigurationManager, unbind = unregisterConfigurationManager]
	    }
	    located in bundle = org.wso2.carbon.identity.application.authenticator.basicauth_6.8.20.6 [245]
    ]
    ```



## Related Issues
- https://github.com/wso2/product-is/issues/16204#issue-1792919235